### PR TITLE
[feat] Member Domain MVC 및 기본 CRUD API 생성

### DIFF
--- a/springTemplate/build.gradle
+++ b/springTemplate/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
 	implementation group: 'com.google.code.gson', name: 'gson' // for ErrorResponder 등
 
+	runtimeOnly 'com.h2database:h2' // for h2 in-memory database
+
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0' // p6spy for  logging tracktion
 }
 

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberPatchReqDto.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberPatchReqDto.java
@@ -1,0 +1,26 @@
+package neoguri.springTemplate.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import neoguri.springTemplate.domain.member.entity.Member;
+
+@Getter @Setter
+public class MemberPatchReqDto {
+
+    private String password;
+    private String nickname;
+    private String profile;
+    private Member.MemberStatus memberStatus;
+
+    /**
+     * 밸류지정방식
+     */
+    public Member toEntity() {
+        return new Member().builder()
+                .password(this.password)
+                .nickname(this.nickname)
+                .profile(this.profile)
+                .memberStatus(this.memberStatus)
+                .build();
+    }
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberPostReqDto.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberPostReqDto.java
@@ -1,0 +1,27 @@
+package neoguri.springTemplate.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import neoguri.springTemplate.domain.member.entity.Member;
+
+@Getter @Setter
+public class MemberPostReqDto {
+
+    private String email;
+
+    private String password;
+
+    private String nickname;
+
+    private String profile;
+
+    public Member toEntity() {
+        return new Member().builder()
+                .email(this.email)
+                .password(this.password)
+                .nickname(this.nickname)
+                .profile(this.profile)
+                .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
+                .build();
+    }
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberResDto.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/dto/MemberResDto.java
@@ -1,0 +1,33 @@
+package neoguri.springTemplate.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import neoguri.springTemplate.auditing.BaseTimeEntity;
+import neoguri.springTemplate.domain.member.entity.Member;
+
+@Getter @Setter
+public class MemberResDto extends BaseTimeEntity {
+
+    private Long memberId;
+
+    private String email;
+
+    private String nickname;
+
+    private String profile;
+
+    private String memberStatus;
+
+
+    public MemberResDto(Member member) {
+        this.memberId = member.getMemberId();
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.profile = member.getProfile();
+        this.memberStatus = member.getMemberStatus().getStatus();
+        super.setCreatedAt(member.getCreatedAt());
+        super.setModifiedAt(member.getModifiedAt());
+    }
+}
+
+

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/entity/Member.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/entity/Member.java
@@ -1,0 +1,92 @@
+package neoguri.springTemplate.domain.member.entity;
+
+import lombok.*;
+import neoguri.springTemplate.auditing.BaseTimeEntity;
+import neoguri.springTemplate.exception.dto.BusinessLogicException;
+import neoguri.springTemplate.exception.exceptionCode.ExceptionCode;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @Setter // 시큐리티 MemberDetailsService 내 MemberDetails생성을 위해 적용 (추후 변경 검토)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
+    @Setter // 시큐리티 MemberDetailsService 내 MemberDetails생성을 위해 적용 (추후 변경 검토)
+    private String email;
+
+    @Setter
+    private String password;
+
+    private String nickname;
+
+    private String profile;
+
+    private String oauthId;
+
+    private String oauthAccessToken;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)  // 컬럼설정 지정 안할시 오류 발생 => Unable to instantiate custom type: org.hibernate.type.EnumType 에러발생
+    private MemberStatus memberStatus;
+
+    /**
+     * Member 객체에 대한 역할 테이블을 자동 생생 후 역할을 부여 (시큐리티를 통해 작동)
+     */
+    @Setter // 시큐리티 MemberDetailsService 내 MemberDetails생성을 위해 적용 (추후 변경 검토)
+    @ElementCollection(fetch = FetchType.EAGER)
+    List<String> roles = new ArrayList<>();
+
+
+    /**
+     * 회원상태 Enum관리 : default값은 MEMBER_ACTIVE로 필드에서 지정
+     */
+    @NoArgsConstructor
+    public enum MemberStatus {
+        MEMBER_ACTIVE("활동중"),
+        MEMBER_SLEEP("휴면계정"),
+        MEMBER_QUIT("탈퇴 계정");
+
+        @Getter
+        private String status;
+
+        MemberStatus(String status) {
+            this.status = status;
+        }
+    }
+
+
+    /**
+     * 기본 프로필 지정
+     */
+    public void defaultProfile() {
+        if(this.profile == null)
+        this.profile = "https://scontent-gmp1-1.xx.fbcdn.net/v/t1.18169-9/527016_499021583525593_732357164_n.jpg?_nc_cat=107&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=CdbnqyyFWXkAX_obHCp&_nc_ht=scontent-gmp1-1.xx&oh=00_AfDBQSsLnCXMKoAPnGFrOeSBgvMp__vgjXLEqmtS6etfcw&oe=63F1DB6A";
+    }
+
+
+    /**
+     * 비즈니스 로직 숨기기용도 (feat.DDD)
+     */
+    public Member verifyMember(Optional<Member> optMember) {
+        return optMember.orElseThrow(()->new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+    }
+
+    public void modifyEmail(String email) {this.email = email;}
+    public void modifyPassword(String password){ if(password != null) this.password = password; }
+    public void modifyNickname(String nickname){ if(nickname!=null) this.nickname = nickname; }
+    public void modifyProfile(String profile){ if(profile!=null) this.profile = profile; }
+    public void modifyMemberStatus(MemberStatus status){ this.memberStatus = status; }
+    public void withdrawMember(){ this.memberStatus = MemberStatus.MEMBER_QUIT; }
+    public void modifyOauthToken(String oauthAccessToken){ this.oauthAccessToken = oauthAccessToken; }
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
@@ -3,13 +3,18 @@ package neoguri.springTemplate.domain.member.mvc;
 import lombok.RequiredArgsConstructor;
 import neoguri.springTemplate.domain.member.dto.MemberPatchReqDto;
 import neoguri.springTemplate.domain.member.dto.MemberPostReqDto;
+import neoguri.springTemplate.domain.member.dto.MemberResDto;
 import neoguri.springTemplate.domain.member.entity.Member;
+import neoguri.springTemplate.dto.MultiResDto;
 import neoguri.springTemplate.dto.SingleResDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,6 +47,61 @@ public class MemberController {
         memberService.modifyMember(memberPatchReqDto.toEntity(), memberId);
 
         return new ResponseEntity<>(new SingleResDto<>("Success Modify"), HttpStatus.OK);
+    }
+
+
+
+    /**
+     * Delete 요청
+     * 애너테이션은 delete 요청을 받을 것이므로, DeleteMapping으로 받음
+     * 상태변환을 할 예정이므로, HttpStatus는 NO_CONTENT가 아닌 OK로 함
+     * 회원탈퇴(withdraw) 후 성공 메세지 반환
+     * @return "data" : "성공 메세지"
+     */
+    @DeleteMapping("/remove/{memberId}")
+    public ResponseEntity<SingleResDto<String>> withdrawMember (@RequestParam Long memberId) {
+        memberService.withdrawMember(memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("정상적으로 탈퇴되었습니다."), HttpStatus.OK);
+    }
+
+
+    /**
+     * 회원 삭제 메소드
+     * @return 삭제 성공 메세지
+     */
+    @DeleteMapping("/delete/{memberId}")
+    public ResponseEntity<SingleResDto<String>> deleteMember (@RequestParam Long memberId) {
+        memberService.removeMember(memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
+    }
+
+
+    /**
+     * 단일 Get 요청
+     * @return "data" : "단일 객체에 대한 응답정보"
+     */
+    @GetMapping("/find/{memberId}")
+    public ResponseEntity<SingleResDto<MemberResDto>> getMember (@RequestParam Long memberId) {
+        Member member = memberService.findMember(memberId);
+        MemberResDto response = new MemberResDto(member);
+
+        return new ResponseEntity<>(new SingleResDto<>(response), HttpStatus.OK);
+    }
+
+
+    /**
+     * Page Get 요청
+     * @return "data" : "String"
+     */
+    @GetMapping("/find-all")
+    public ResponseEntity<MultiResDto<MemberResDto>> getMembers (Pageable pageable) {
+        Page<Member> page = memberService.findMembers(pageable);
+        Page<MemberResDto> response = page.map(MemberResDto::new);
+        List<MemberResDto> list = response.stream().collect(Collectors.toList());
+
+        return new ResponseEntity<>(new MultiResDto<>(list, page), HttpStatus.OK);
     }
 
 }

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
@@ -1,0 +1,33 @@
+package neoguri.springTemplate.domain.member.mvc;
+
+import lombok.RequiredArgsConstructor;
+import neoguri.springTemplate.domain.member.dto.MemberPostReqDto;
+import neoguri.springTemplate.domain.member.entity.Member;
+import neoguri.springTemplate.dto.SingleResDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * Post 요청
+     * @return "data" : "String"
+     */
+    @PostMapping
+    public ResponseEntity<SingleResDto<Long>> postMember (@RequestBody MemberPostReqDto memberPostReqDto) {
+        Member savedMember = memberService.createMember(memberPostReqDto.toEntity());
+
+        return new ResponseEntity<>(new SingleResDto<>(savedMember.getMemberId()), HttpStatus.CREATED);
+    }
+
+
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberController.java
@@ -1,15 +1,15 @@
 package neoguri.springTemplate.domain.member.mvc;
 
 import lombok.RequiredArgsConstructor;
+import neoguri.springTemplate.domain.member.dto.MemberPatchReqDto;
 import neoguri.springTemplate.domain.member.dto.MemberPostReqDto;
 import neoguri.springTemplate.domain.member.entity.Member;
 import neoguri.springTemplate.dto.SingleResDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +29,19 @@ public class MemberController {
         return new ResponseEntity<>(new SingleResDto<>(savedMember.getMemberId()), HttpStatus.CREATED);
     }
 
+
+    /**
+     * Patch 요청
+     * @return "data" : "String"
+     * @param memberPatchReqDto : 요청 Body
+     * @return void
+     */
+    @PatchMapping("/edit/{memberId}")
+    public ResponseEntity<SingleResDto<String>> patchMember (@RequestBody MemberPatchReqDto memberPatchReqDto,
+                                                             @RequestParam Long memberId) {
+        memberService.modifyMember(memberPatchReqDto.toEntity(), memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("Success Modify"), HttpStatus.OK);
+    }
 
 }

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberRepository.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberRepository.java
@@ -1,0 +1,16 @@
+package neoguri.springTemplate.domain.member.mvc;
+
+import neoguri.springTemplate.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    @Query(value = "SELECT m FROM Member m WHERE m.nickname =:nickname")
+    Optional<Member> findByNickname(String nickname);
+
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberService.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberService.java
@@ -1,0 +1,38 @@
+package neoguri.springTemplate.domain.member.mvc;
+
+import lombok.RequiredArgsConstructor;
+import neoguri.springTemplate.domain.member.entity.Member;
+import neoguri.springTemplate.exception.dto.BusinessLogicException;
+import neoguri.springTemplate.exception.exceptionCode.ExceptionCode;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+//    private final PasswordEncoder passwordEncoder; // Spring Security에서 제공하는 모듈
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member createMember(Member member) {
+        verifyNotExistEmail(member.getEmail());
+        member.defaultProfile();
+//        String encryptedPassword = passwordEncoder.encode(member.getPassword());
+//        member.setPassword(encryptedPassword);
+
+        return memberRepository.save(member);
+    }
+
+
+    /**
+     * 이메일 중복 확인 메소드. 이메일 존재시 예외 발생
+     */
+    public void verifyNotExistEmail(String email) {
+        Optional<Member> optionalEmail = memberRepository.findByEmail(email);
+        if (optionalEmail.isPresent()) throw new BusinessLogicException(ExceptionCode.EMAIL_EXIST);
+    }
+
+}

--- a/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberService.java
+++ b/springTemplate/src/main/java/neoguri/springTemplate/domain/member/mvc/MemberService.java
@@ -28,6 +28,29 @@ public class MemberService {
 
 
     /**
+     * 들어오는 값에 따라, 다음의 Patch 요청을 개별적으로 관리 가능합니다. (null이 아닐경우 수정되는 방식 미적용)
+     * 1. 회원 정보 변경 가능
+     * 2. 회원 상태 변경 가능
+     * 비즈니스 로직은 Member Entity 내에서 처리
+     */
+    @Transactional
+    public void modifyMember(Member member, Long memberId) {
+        Member existMember = new Member().verifyMember(memberRepository.findById(memberId));
+//        Optional.ofNullable(member.getPassword()).ifPresent(pw -> existMember.modifyPassword(passwordEncoder.encode(pw))); // 해제시, 수정중 비밀번호를 필수항목으로 지정 가능
+
+        String encodedPassword = null;
+        Optional.ofNullable(encodedPassword).ifPresent(existMember::modifyPassword);
+        Optional.ofNullable(member.getNickname()).ifPresent(existMember::modifyNickname);
+        Optional.ofNullable(member.getProfile()).ifPresent(existMember::modifyProfile);  // 현재 profile의 경우 단순 URI상태. 추후 파일로 변경 예정
+        Optional.ofNullable(member.getMemberStatus()).ifPresent(existMember::modifyMemberStatus);
+
+        memberRepository.save(existMember);
+    }
+
+
+
+
+    /**
      * 이메일 중복 확인 메소드. 이메일 존재시 예외 발생
      */
     public void verifyNotExistEmail(String email) {

--- a/springTemplate/src/main/resources/application.yml
+++ b/springTemplate/src/main/resources/application.yml
@@ -9,6 +9,13 @@ server:
 
 ### Spring Settings
 spring:
+  ## H2 사용시
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  datasource:
+    url: jdbc:h2:mem:test
   ## 프로젝트 시작시 사용할 application.yml 파일 선택
   profiles:
     active: local  # 없으면 default 자동실행됨. application-server.yml, application-local.yml 등 추가로 만들어서 설정이 가능


### PR DESCRIPTION
## PR Type
어떤 종류의 PR인가요?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기
Issue Number: 6


## 무엇이 추가 되었나요?
- 회원 도메인(Member)를 위한 기본 MVC 모델 구현
- 회원 도메인(Member)의 기본 CRUD 구현 (SpringSecurity 미적용 버전)
- H2 인메모리 서버 사용을 위한 application.yml 설정 추가

## 기타 정보
- 현재 PR의 기본 Member 도메인의 경우, Spring security가 적용되어 있지 않은 기본 구조입니다.
  따라서 아래의 항목이 적용되어 있지 않습니다.
- 비밀번호에 대해 Password인코딩 미적용
- Member에 대해 Role(인가권한) 미적용
- 로그인 검증시, JWT를 이용한 자동검증 미적용(현재는 memberId(식별자)를 전달받는 구조로 된 수동 인증 방식)

- 추후 Spring security 추가 후 적용될 예정이며, 이후 이메일/비밀번호검증 등 추가 메소드가 추가될 예정입니다.